### PR TITLE
WIP - imported from other module

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,10 @@ const client = new HttpClient(options);
 
 | option              | default      | type       | required | details                                                                                                                                    |
 |---------------------|--------------|------------|----------|--------------------------------------------------------------------------------------------------------------------------------------------|
-| abortController     | `undefined`  | `object`   | no       | See [abortController](#abortController)                                                                                                        |
+| abortController     | `undefined`  | `object`   | no       | See [abortController](#abortController)                                                                                                    |
 | connections         | `50`         | `number`   | no       | See [connections](#connections)                                                                                                            |
-| fallback            | `undefined`  | `function` | no       | Function to call when requests fail                                                                                                        |
+| fallback            | `undefined`  | `function` | no       | Function to call when requests fail, see [fallback](#fallback)                                                                             |
+| followRedirects     | `false`      | `boolean`  | no       | Flag for whether to follow redirects or not, see [followRedirects](#followRedirects).                                                      |
 | keepAliveMaxTimeout | `undefined`  | `number`   | no       | See [keepAliveMaxTimeout](#keepAliveMaxTimeout)                                                                                            |
 | keepAliveTimeout    | `undefined`  | `number`   | no       | See [keepAliveTimeout](#keepAliveTimeout)                                                                                                  |
 | logger              | `undefined ` | `object`   | no       | A logger which conform to a log4j interface                                                                                                |
@@ -71,6 +72,15 @@ Optional function to run when a request fails.
 ```js
 // TBA
 ```
+
+##### followRedirects
+
+TODO!!!   decide what to do with the redirects stuff...
+
+By default, the library does not follow redirect.
+If set to true it will follow redirects according to `maxRedirections`.
+It will by default throw on reaching `throwOnMaxRedirects`
+
 
 ##### keepAliveMaxTimeout
 

--- a/README.md
+++ b/README.md
@@ -39,22 +39,28 @@ const client = new HttpClient(options);
 
 #### options
 
-| option                | default      | type       | required | details                                                                                                                                    |
-|-----------------------|--------------|------------|----------|--------------------------------------------------------------------------------------------------------------------------------------------|
-| connections           | `50`         | `number`   | no       | See [connections](#connections)                                                                                                            |
-| fallback              | `undefined`  | `function` | no       | Function to call when requests fail                                                                                                        |
-| keepAliveMaxTimeout   | `undefined`  | `number`   | no       | See [keepAliveMaxTimeout](#keepAliveMaxTimeout)                                                                                            |
-| keepAliveTimeout      | `undefined`  | `number`   | no       | See [keepAliveTimeout](#keepAliveTimeout)                                                                                                  |
-| logger                | `undefined ` | `object`   | no       | A logger which conform to a log4j interface                                                                                                |
-| pipelining            | `10`         | `number`   | no       | See [pipelining](#pipelining)                                                                                                              |
-| reset                 | `2000`       | `number`   | no       | Circuit breaker: How long, in milliseconds, to wait before a tripped circuit should be reset.                                              |
-| threshold             | `25`         | `number`   | no       | Circuit breaker: How many, in %, requests should error before the circuit should trip. Ex; when 25% of requests fail, trip the circuit.    |
-| throwOn400            | `false`      | `boolean`  | no       | If the client should throw on HTTP 400 errors.If true, HTTP 400 errors will counts against tripping the circuit.                           |
-| throwOn500            | `true`       | `boolean`  | no       | If the client should throw on HTTP 500 errors.If true, HTTP 500 errors will counts against tripping the circuit.                           |
-| timeout               | `500`        | `number`   | no       | Circuit breaker: How long, in milliseconds, a request can maximum take. Requests exceeding this limit counts against tripping the circuit. |
+| option              | default      | type       | required | details                                                                                                                                    |
+|---------------------|--------------|------------|----------|--------------------------------------------------------------------------------------------------------------------------------------------|
+| abortController     | `undefined`  | `object`   | no       | See [abortController](#abortController)                                                                                                        |
+| connections         | `50`         | `number`   | no       | See [connections](#connections)                                                                                                            |
+| fallback            | `undefined`  | `function` | no       | Function to call when requests fail                                                                                                        |
+| keepAliveMaxTimeout | `undefined`  | `number`   | no       | See [keepAliveMaxTimeout](#keepAliveMaxTimeout)                                                                                            |
+| keepAliveTimeout    | `undefined`  | `number`   | no       | See [keepAliveTimeout](#keepAliveTimeout)                                                                                                  |
+| logger              | `undefined ` | `object`   | no       | A logger which conform to a log4j interface                                                                                                |
+| pipelining          | `10`         | `number`   | no       | See [pipelining](#pipelining)                                                                                                              |
+| reset               | `2000`       | `number`   | no       | Circuit breaker: How long, in milliseconds, to wait before a tripped circuit should be reset.                                              |
+| threshold           | `25`         | `number`   | no       | Circuit breaker: How many, in %, requests should error before the circuit should trip. Ex; when 25% of requests fail, trip the circuit.    |
+| throwOn400          | `false`      | `boolean`  | no       | If the client should throw on HTTP 400 errors.If true, HTTP 400 errors will counts against tripping the circuit.                           |
+| throwOn500          | `true`       | `boolean`  | no       | If the client should throw on HTTP 500 errors.If true, HTTP 500 errors will counts against tripping the circuit.                           |
+| timeout             | `500`        | `number`   | no       | Circuit breaker: How long, in milliseconds, a request can maximum take. Requests exceeding this limit counts against tripping the circuit. |
 
+
+##### abortController
+
+Passing in an [AbortController](https://nodejs.org/docs/latest/api/globals.html#globals_class_abortcontroller) enables aborting requests.
 
 ##### connections
+
 Property is sent to the underlying http library.
 See library docs on [connections](https://undici.nodejs.org/#/docs/api/Pool?id=parameter-pooloptions)
 
@@ -120,7 +126,29 @@ If the client should throw on http 500 errors. If true, http 500 errors will cou
 
 ## Methods
 
+### async request(options = {})
 
+Sends a request using the passed in options object.
+
+| name    | type            | description                                     |
+|---------|-----------------|-------------------------------------------------|
+| origin  | `string \| URL` | Request origin, ex `https://server.domain:9090` |
+| path    | `string`        | URL path, ex `/foo`                             |
+| method  | `string`        | HTTP method name                                |
+| headers | `object`        | Object with key / value which are strings       |
+| query   | `object`        | Object with key / value which are strings       |
+| signal  | `AbortSignal`   | Abort signal for canceling requests.            |
+
+For a complete list of options, consult the [undici documentation](https://undici.nodejs.org/#/?id=undicirequesturl-options-promise).
+
+
+### async close()
+
+Closes the client and it's connections.
+
+## HttpClientError
+
+Errors thrown from the library will be of the class `HttpClientError`
 
 [@metrics/metric]: https://github.com/metrics-js/metric '@metrics/metric'
 [abslog]: https://github.com/trygve-lie/abslog 'abslog'

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ⚠️ This project is still work in progress, should not be used for anything just yet.
 
-Generic http client built on [undici](undici.nodejs.org/) with a circuit breaker, error handling and metrics out of the box.
+Generic http client built on [undici] with a circuit breaker using [opossum], error handling and metrics out of the box.
 
 [![GitHub Actions status](https://github.com/podium-lib/http-client/workflows/Run%20Lint%20and%20Tests/badge.svg)](https://github.com/podium-lib/layout/actions?query=workflow%3A%22Run+Lint+and+Tests%22)
 [![Known Vulnerabilities](https://snyk.io/test/github/podium-lib/http-client/badge.svg)](https://snyk.io/test/github/podium-lib/http-client)
@@ -39,15 +39,42 @@ const client = new HttpClient(options);
 
 #### options
 
-| option     | default | type      | required | details                                                                                                                                    |
-|------------|---------|-----------|----------|--------------------------------------------------------------------------------------------------------------------------------------------|
-| threshold  | `null`  | `number`  | `25`     | Circuit breaker: How many, in %, requests should error before the circuit should trip. Ex; when 25% of requests fail, trip the circuit.    |
-| timeout    | `null`  | `number`  | `500`    | Circuit breaker: How long, in milliseconds, a request can maximum take. Requests exceeding this limit counts against tripping the circuit. |
-| throwOn400 | `false` | `boolean` | `false`  | If the client sahould throw on HTTP 400 errors.If true, HTTP 400 errors will counts against tripping the circuit.                          |
-| throwOn500 | `false` | `boolean` | `true`   | If the client sahould throw on HTTP 500 errors.If true, HTTP 500 errors will counts against tripping the circuit.                          |
-| reset      | `false` | `number`  | `2000`   | Circuit breaker: How long, in milliseconds, to wait before a tripped circuit should be reset.                                              |
-| logger     | `null`  | `àb`      | `false`  | A logger which conform to a log4j interface                                                                                                |
+| option                | default      | type       | required | details                                                                                                                                    |
+|-----------------------|--------------|------------|----------|--------------------------------------------------------------------------------------------------------------------------------------------|
+| connections           | `50`         | `number`   | no       | See [connections](#connections)                                                                                                            |
+| fallback              | `undefined`  | `function` | no       | Function to call when requests fail                                                                                                        |
+| keepAliveMaxTimeout   | `undefined`  | `number`   | no       | See [keepAliveMaxTimeout](#keepAliveMaxTimeout)                                                                                            |
+| keepAliveTimeout      | `undefined`  | `number`   | no       | See [keepAliveTimeout](#keepAliveTimeout)                                                                                                  |
+| logger                | `undefined ` | `object`   | no       | A logger which conform to a log4j interface                                                                                                |
+| pipelining            | `10`         | `number`   | no       | See [pipelining](#pipelining)                                                                                                              |
+| reset                 | `2000`       | `number`   | no       | Circuit breaker: How long, in milliseconds, to wait before a tripped circuit should be reset.                                              |
+| threshold             | `25`         | `number`   | no       | Circuit breaker: How many, in %, requests should error before the circuit should trip. Ex; when 25% of requests fail, trip the circuit.    |
+| throwOn400            | `false`      | `boolean`  | no       | If the client should throw on HTTP 400 errors.If true, HTTP 400 errors will counts against tripping the circuit.                           |
+| throwOn500            | `true`       | `boolean`  | no       | If the client should throw on HTTP 500 errors.If true, HTTP 500 errors will counts against tripping the circuit.                           |
+| timeout               | `500`        | `number`   | no       | Circuit breaker: How long, in milliseconds, a request can maximum take. Requests exceeding this limit counts against tripping the circuit. |
 
+
+##### connections
+Property is sent to the underlying http library.
+See library docs on [connections](https://undici.nodejs.org/#/docs/api/Pool?id=parameter-pooloptions)
+
+##### fallback
+
+Optional function to run when a request fails.
+
+```js
+// TBA
+```
+
+##### keepAliveMaxTimeout
+
+Property is sent to the underlying http library.
+See library docs on [keepAliveTimeout](https://undici.nodejs.org/#/docs/api/Client?id=parameter-clientoptions)
+
+##### keepAliveMaxTimeout
+
+Property is sent to the underlying http library.
+See library docs on [keepAliveMaxTimeout](https://undici.nodejs.org/#/docs/api/Client?id=parameter-clientoptions)
 
 ##### logger
 
@@ -67,13 +94,35 @@ const layout = new Layout({
 Under the hood [abslog] is used to abstract out logging. Please see [abslog] for
 further details.
 
+##### pipelining
+
+Property is sent to the underlying http library.
+See library docs on [pipelining](https://undici.nodejs.org/#/?id=pipelining)
+
+##### reset
+Circuit breaker: How long, in milliseconds, to wait before a tripped circuit should be reset.
+
+##### threshold
+
+Circuit breaker: How many, in %, requests should error before the circuit should trip. Ex; when 25% of requests fail, trip the circuit.
+
+##### timeout
+Circuit breaker: How long, in milliseconds, a request can maximum take. Requests exceeding this limit counts against tripping the circuit.
+
+##### throwOn400
+
+If the client should throw on http 400 errors. If true, http 400 errors will count against tripping the circuit.
+
+##### throwOn500
+If the client should throw on http 500 errors. If true, http 500 errors will count against tripping the circuit.
+
+
 
 ## Methods
 
-### async request(options)
-### async close()
-### fallback()
 
 
 [@metrics/metric]: https://github.com/metrics-js/metric '@metrics/metric'
 [abslog]: https://github.com/trygve-lie/abslog 'abslog'
+[undici]: https://undici.nodejs.org/
+[opossum]: https://github.com/nodeshift/opossum/

--- a/README.md
+++ b/README.md
@@ -4,21 +4,76 @@
 
 Generic http client built on [undici](undici.nodejs.org/) with a circuit breaker, error handling and metrics out of the box.
 
-[![Dependencies](https://img.shields.io/david/podium-lib/http-client.svg)](https://david-dm.org/podium-lib/http-client)
 [![GitHub Actions status](https://github.com/podium-lib/http-client/workflows/Run%20Lint%20and%20Tests/badge.svg)](https://github.com/podium-lib/layout/actions?query=workflow%3A%22Run+Lint+and+Tests%22)
 [![Known Vulnerabilities](https://snyk.io/test/github/podium-lib/http-client/badge.svg)](https://snyk.io/test/github/podium-lib/http-client)
 
 ## Installation
 
+*Note!* Requires Node.js v20 or later.
+
 ```bash
-$ npm install @podium/http-client
+npm install @podium/http-client
 ```
 
 ## Usage
 
-
 ```js
+import client from '@podium/http-client';
+const client = new HttpClient(options);
 
+const response = await client.request({ path: '/', origin: 'https://host.domain' })
+if (response.ok) {
+    //
+}
 ```
 
-## Constructor
+## API
+
+### Constructor
+
+```js
+import client from '@podium/http-client';
+
+const client = new HttpClient(options);
+```
+
+#### options
+
+| option     | default | type      | required | details                                                                                                                                    |
+|------------|---------|-----------|----------|--------------------------------------------------------------------------------------------------------------------------------------------|
+| threshold  | `null`  | `number`  | `25`     | Circuit breaker: How many, in %, requests should error before the circuit should trip. Ex; when 25% of requests fail, trip the circuit.    |
+| timeout    | `null`  | `number`  | `500`    | Circuit breaker: How long, in milliseconds, a request can maximum take. Requests exceeding this limit counts against tripping the circuit. |
+| throwOn400 | `false` | `boolean` | `false`  | If the client sahould throw on HTTP 400 errors.If true, HTTP 400 errors will counts against tripping the circuit.                          |
+| throwOn500 | `false` | `boolean` | `true`   | If the client sahould throw on HTTP 500 errors.If true, HTTP 500 errors will counts against tripping the circuit.                          |
+| reset      | `false` | `number`  | `2000`   | Circuit breaker: How long, in milliseconds, to wait before a tripped circuit should be reset.                                              |
+| logger     | `null`  | `àb`      | `false`  | A logger which conform to a log4j interface                                                                                                |
+
+
+##### logger
+
+Any log4j compatible logger can be passed in and will be used for logging.
+Console is also supported for easy test / development.
+
+Example:
+
+```js
+const layout = new Layout({
+    name: 'myLayout',
+    pathname: '/foo',
+    logger: console,
+});
+```
+
+Under the hood [abslog] is used to abstract out logging. Please see [abslog] for
+further details.
+
+
+## Methods
+
+### async request(options)
+### async close()
+### fallback()
+
+
+[@metrics/metric]: https://github.com/metrics-js/metric '@metrics/metric'
+[abslog]: https://github.com/trygve-lie/abslog 'abslog'

--- a/examples/failing.js
+++ b/examples/failing.js
@@ -1,0 +1,29 @@
+import HttpClient, { HttpClientError } from '../lib/http-client.js';
+
+/**
+ * Example of the circuit breaker opening on a failing request.
+ */
+const client = new HttpClient();
+try {
+    await client.request({
+        origin: 'http://localhost:9099',
+        path: '/',
+        method: 'GET',
+    });
+} catch (_) {
+    // Mute the first one, next request should hit an open breaker
+}
+
+try {
+    await client.request({
+        origin: 'http://localhost:9099',
+        path: '/',
+        method: 'GET',
+    });
+} catch (err) {
+    if (err instanceof HttpClientError) {
+        if (err.code === HttpClientError.ServerDown) {
+            console.error('Server unavailable..');
+        }
+    }
+}

--- a/examples/success.js
+++ b/examples/success.js
@@ -1,0 +1,11 @@
+import HttpClient from '../lib/http-client.js';
+
+const client = new HttpClient();
+const response = await client.request({
+    origin: 'https://www.google.com',
+    path: '/',
+    method: 'GET',
+    maxRedirections: 0,
+});
+
+console.log(response.statusCode);

--- a/lib/http-client.js
+++ b/lib/http-client.js
@@ -1,4 +1,4 @@
-import { Agent, setGlobalDispatcher, request, MockAgent } from 'undici';
+import { Agent, request } from 'undici';
 import createError from 'http-errors';
 import Opossum from 'opossum';
 import abslog from 'abslog';
@@ -31,6 +31,7 @@ export default class HttpClient extends EventEmitter {
      */
     constructor({
         abortController = undefined,
+        autoRenewAbortController = false,
         keepAliveMaxTimeout = undefined,
         keepAliveTimeout = undefined,
         connections = 50,
@@ -55,6 +56,7 @@ export default class HttpClient extends EventEmitter {
             ...(this.#abortController && {
                 abortController: this.#abortController,
             }),
+            ...(autoRenewAbortController && { autoRenewAbortController }),
             errorThresholdPercentage: threshold, // When X% of requests fail, trip the circuit
             resetTimeout: reset, // After X milliseconds, try again.
             timeout, // If our function takes longer than X milliseconds, trigger a failure
@@ -127,10 +129,4 @@ export default class HttpClient extends EventEmitter {
             await this.#agent.close();
         }
     }
-
-    // static mock(origin) {
-    //     const agent = new MockAgent();
-    //     setGlobalDispatcher(agent);
-    //     return agent.get(origin);
-    // }
 }

--- a/lib/http-client.js
+++ b/lib/http-client.js
@@ -2,6 +2,7 @@ import { Agent, setGlobalDispatcher, request, MockAgent } from 'undici';
 import createError from 'http-errors';
 import Opossum from 'opossum';
 import abslog from 'abslog';
+import EventEmitter from 'node:events';
 
 /**
  * @typedef HttpClientOptions
@@ -17,17 +18,19 @@ import abslog from 'abslog';
  * @property {Number} reset - Circuit breaker: How long, in milliseconds, to wait before a tripped circuit should be reset.
  **/
 
-export default class HttpClient {
+export default class HttpClient extends EventEmitter {
     #throwOn400;
     #throwOn500;
     #breaker;
     #logger;
     #agent;
+    #abortController;
 
     /**
      * @property {HttpClientOptions} options - options
      */
     constructor({
+        abortController = undefined,
         keepAliveMaxTimeout = undefined,
         keepAliveTimeout = undefined,
         connections = 50,
@@ -38,13 +41,20 @@ export default class HttpClient {
         timeout = 500,
         logger = undefined,
         reset = 20000,
+        fallback = undefined,
     } = {}) {
+        super();
         this.#logger = abslog(logger);
         this.#throwOn400 = throwOn400;
         this.#throwOn500 = throwOn500;
+        // Add runtime check
+        this.#abortController = abortController;
 
         // TODO; Can we avoid bind here in a nice way?????
         this.#breaker = new Opossum(this.#request.bind(this), {
+            ...(this.#abortController && {
+                abortController: this.#abortController,
+            }),
             errorThresholdPercentage: threshold, // When X% of requests fail, trip the circuit
             resetTimeout: reset, // After X milliseconds, try again.
             timeout, // If our function takes longer than X milliseconds, trigger a failure
@@ -55,6 +65,17 @@ export default class HttpClient {
             keepAliveTimeout, // TODO unknown option, consider removing
             connections,
             pipelining, // TODO unknown option, consider removing
+        });
+
+        if (fallback) {
+            this.fallback(fallback);
+        }
+
+        this.#breaker.on('open', () => {
+            this.emit('open');
+        });
+        this.#breaker.on('close', () => {
+            this.emit('close');
         });
     }
 
@@ -88,8 +109,12 @@ export default class HttpClient {
         };
     }
 
-    fallback(fn) {
-        this.#breaker.fallback(fn);
+    /**
+     * Function called if the request fails.
+     * @param {Function} func
+     */
+    fallback(func) {
+        this.#breaker.fallback(func);
     }
 
     async request(options = {}) {
@@ -103,9 +128,9 @@ export default class HttpClient {
         }
     }
 
-    static mock(origin) {
-        const agent = new MockAgent();
-        setGlobalDispatcher(agent);
-        return agent.get(origin);
-    }
+    // static mock(origin) {
+    //     const agent = new MockAgent();
+    //     setGlobalDispatcher(agent);
+    //     return agent.get(origin);
+    // }
 }

--- a/lib/http-client.js
+++ b/lib/http-client.js
@@ -1,4 +1,4 @@
-import { Agent, request } from 'undici';
+import { Agent, request, interceptors } from 'undici';
 import createError from 'http-errors';
 import Opossum from 'opossum';
 import abslog from 'abslog';
@@ -35,6 +35,7 @@ export default class HttpClient {
         autoRenewAbortController = false,
         connections = 50,
         fallback = undefined,
+        followRedirects = false,
         keepAliveMaxTimeout = undefined,
         keepAliveTimeout = undefined,
         logger = undefined,
@@ -62,12 +63,19 @@ export default class HttpClient {
             timeout,
         });
 
-        this.#agent = new Agent({
-            keepAliveMaxTimeout, // TODO unknown option, consider removing
-            keepAliveTimeout, // TODO unknown option, consider removing
+        const { redirect } = interceptors;
+        let agent = new Agent({
+            keepAliveMaxTimeout,
+            keepAliveTimeout,
             connections,
-            pipelining, // TODO unknown option, consider removing
+            pipelining,
         });
+        if (followRedirects) {
+            agent = agent.compose(
+                redirect({ maxRedirections: 1, throwOnMaxRedirects: true }),
+            );
+        }
+        this.#agent = agent;
 
         if (fallback) {
             this.#hasFallback = true;
@@ -77,11 +85,8 @@ export default class HttpClient {
 
     async #request(options = {}) {
         const { statusCode, headers, trailers, body } = await request({
+            dispatcher: this.#agent,
             ...options,
-            dispatcher: new Agent({
-                keepAliveTimeout: 10,
-                keepAliveMaxTimeout: 10,
-            }),
         });
 
         if (this.#throwOn400 && statusCode >= 400 && statusCode <= 499) {
@@ -157,6 +162,7 @@ export default class HttpClient {
  * Error class for the client
  */
 export class HttpClientError extends Error {
+    // Not sure if there is a need for this tbh, but I threw it in there so we can see how it feels.
     static ServerDown = 'EOPENBREAKER';
     constructor(message, { code, cause, options }) {
         super(message);

--- a/lib/http-client.js
+++ b/lib/http-client.js
@@ -76,7 +76,13 @@ export default class HttpClient {
     }
 
     async #request(options = {}) {
-        const { statusCode, headers, trailers, body } = await request(options);
+        const { statusCode, headers, trailers, body } = await request({
+            ...options,
+            dispatcher: new Agent({
+                keepAliveTimeout: 10,
+                keepAliveMaxTimeout: 10,
+            }),
+        });
 
         if (this.#throwOn400 && statusCode >= 400 && statusCode <= 499) {
             // Body must be consumed; https://github.com/nodejs/undici/issues/583#issuecomment-855384858
@@ -151,6 +157,7 @@ export default class HttpClient {
  * Error class for the client
  */
 export class HttpClientError extends Error {
+    static ServerDown = 'EOPENBREAKER';
     constructor(message, { code, cause, options }) {
         super(message);
         this.name = 'HttpClientError';

--- a/lib/http-client.js
+++ b/lib/http-client.js
@@ -17,7 +17,7 @@ import abslog from 'abslog';
  * @property {Number} reset - Circuit breaker: How long, in milliseconds, to wait before a tripped circuit should be reset.
  **/
 
-export default class PodiumHttpClient {
+export default class HttpClient {
     #throwOn400;
     #throwOn500;
     #breaker;
@@ -64,7 +64,7 @@ export default class PodiumHttpClient {
         if (this.#throwOn400 && statusCode >= 400 && statusCode <= 499) {
             // Body must be consumed; https://github.com/nodejs/undici/issues/583#issuecomment-855384858
             const errBody = await body.text();
-            this.#logger.debug(
+            this.#logger.trace(
                 `HTTP ${statusCode} error catched by client. Body: ${errBody}`,
             );
             throw createError(statusCode);
@@ -74,7 +74,7 @@ export default class PodiumHttpClient {
             // Body must be consumed; https://github.com/nodejs/undici/issues/583#issuecomment-855384858
             await body.text();
             const errBody = await body.text();
-            this.#logger.debug(
+            this.#logger.trace(
                 `HTTP ${statusCode} error catched by client. Body: ${errBody}`,
             );
             throw createError(statusCode);
@@ -90,10 +90,6 @@ export default class PodiumHttpClient {
 
     fallback(fn) {
         this.#breaker.fallback(fn);
-    }
-
-    metrics() {
-        // TODO: Implement...
     }
 
     async request(options = {}) {

--- a/lib/http-client.js
+++ b/lib/http-client.js
@@ -22,6 +22,7 @@ export default class HttpClient {
     #abortController;
     #agent;
     #breaker;
+    #hasFallback = false;
     #logger;
     #throwOn400;
     #throwOn500;
@@ -69,6 +70,7 @@ export default class HttpClient {
         });
 
         if (fallback) {
+            this.#hasFallback = true;
             this.#fallback(fallback);
         }
     }
@@ -120,7 +122,7 @@ export default class HttpClient {
         try {
             return await this.#breaker.fire(options);
         } catch (error) {
-            if (!this.fallback) {
+            if (!this.#hasFallback) {
                 throw new HttpClientError(
                     `Error on ${options.method} ${options.origin}${options.path}`,
                     {

--- a/lib/http-client.js
+++ b/lib/http-client.js
@@ -2,29 +2,29 @@ import { Agent, request } from 'undici';
 import createError from 'http-errors';
 import Opossum from 'opossum';
 import abslog from 'abslog';
-import EventEmitter from 'node:events';
 
 /**
  * @typedef HttpClientOptions
- * @property {Number} keepAliveMaxTimeout
- * @property {Number} keepAliveTimeout
- * @property {Number} connections
- * @property {Number} pipelining
- * @property {Boolean} throwOn400 - If the client should throw on http 400 errors. If true, http 400 errors will counts against tripping the circuit.
- * @property {Boolean} throwOn500 - If the client should throw on http 500 errors. If true, http 500 errors will counts against tripping the circuit.
+ * @property {Number} connections - @see https://undici.nodejs.org/#/docs/api/Pool?id=parameter-pooloptions
+ * @property {Number} keepAliveMaxTimeout - @see https://undici.nodejs.org/#/docs/api/Client?id=parameter-clientoptions
+ * @property {Number} keepAliveTimeout - @see https://undici.nodejs.org/#/docs/api/Client?id=parameter-clientoptions
+ * @property {import('abslog')} logger - A logger instance compatible with abslog .
+ * @property {Number} pipelining - @see https://undici.nodejs.org/#/?id=pipelining
+ * @property {Number} reset - Circuit breaker: How long, in milliseconds, to wait before a tripped circuit should be reset.
+ * @property {Boolean} throwOn400 - If the client should throw on http 400 errors. If true, http 400 errors will count against tripping the circuit.
+ * @property {Boolean} throwOn500 - If the client should throw on http 500 errors. If true, http 500 errors will count against tripping the circuit.
  * @property {Number} threshold - Circuit breaker: How many, in %, requests should error before the circuit should trip. Ex; when 25% of requests fail, trip the circuit.
  * @property {Number} timeout - Circuit breaker: How long, in milliseconds, a request can maximum take. Requests exceeding this limit counts against tripping the circuit.
- * @property {import('abslog')} logger - A logger instance compatible with abslog .
- * @property {Number} reset - Circuit breaker: How long, in milliseconds, to wait before a tripped circuit should be reset.
+ * @property {Function} [fallaback=undefined] - Optional function to call as a fallback when breaker is open.
  **/
 
-export default class HttpClient extends EventEmitter {
-    #throwOn400;
-    #throwOn500;
+export default class HttpClient {
+    #abortController;
+    #agent;
     #breaker;
     #logger;
-    #agent;
-    #abortController;
+    #throwOn400;
+    #throwOn500;
 
     /**
      * @property {HttpClientOptions} options - options
@@ -32,23 +32,22 @@ export default class HttpClient extends EventEmitter {
     constructor({
         abortController = undefined,
         autoRenewAbortController = false,
+        connections = 50,
+        fallback = undefined,
         keepAliveMaxTimeout = undefined,
         keepAliveTimeout = undefined,
-        connections = 50,
+        logger = undefined,
         pipelining = 10,
+        reset = 20000,
         throwOn400 = false,
         throwOn500 = true,
         threshold = 25,
         timeout = 500,
-        logger = undefined,
-        reset = 20000,
-        fallback = undefined,
     } = {}) {
-        super();
         this.#logger = abslog(logger);
         this.#throwOn400 = throwOn400;
         this.#throwOn500 = throwOn500;
-        // Add runtime check
+
         this.#abortController = abortController;
 
         // TODO; Can we avoid bind here in a nice way?????
@@ -57,9 +56,9 @@ export default class HttpClient extends EventEmitter {
                 abortController: this.#abortController,
             }),
             ...(autoRenewAbortController && { autoRenewAbortController }),
-            errorThresholdPercentage: threshold, // When X% of requests fail, trip the circuit
-            resetTimeout: reset, // After X milliseconds, try again.
-            timeout, // If our function takes longer than X milliseconds, trigger a failure
+            errorThresholdPercentage: threshold,
+            resetTimeout: reset,
+            timeout,
         });
 
         this.#agent = new Agent({
@@ -72,13 +71,6 @@ export default class HttpClient extends EventEmitter {
         if (fallback) {
             this.fallback(fallback);
         }
-
-        this.#breaker.on('open', () => {
-            this.emit('open');
-        });
-        this.#breaker.on('close', () => {
-            this.emit('close');
-        });
     }
 
     async #request(options = {}) {
@@ -113,16 +105,25 @@ export default class HttpClient extends EventEmitter {
 
     /**
      * Function called if the request fails.
-     * @param {Function} func
+     * @param {import('opossum')} func
      */
     fallback(func) {
         this.#breaker.fallback(func);
     }
 
+    /**
+     * Requests a URL.
+     * @param {any} [options]
+     * @returns {Promise<any>}
+     */
     async request(options = {}) {
         return await this.#breaker.fire(options);
     }
 
+    /**
+     * Closes the client.
+     * @returns {Promise<void>}
+     */
     async close() {
         await this.#breaker.close();
         if (!this.#agent.destroyed && !this.#agent.closed) {

--- a/lib/http-client.js
+++ b/lib/http-client.js
@@ -69,7 +69,7 @@ export default class HttpClient {
         });
 
         if (fallback) {
-            this.fallback(fallback);
+            this.#fallback(fallback);
         }
     }
 
@@ -107,7 +107,7 @@ export default class HttpClient {
      * Function called if the request fails.
      * @param {import('opossum')} func
      */
-    fallback(func) {
+    #fallback(func) {
         this.#breaker.fallback(func);
     }
 
@@ -117,7 +117,20 @@ export default class HttpClient {
      * @returns {Promise<any>}
      */
     async request(options = {}) {
-        return await this.#breaker.fire(options);
+        try {
+            return await this.#breaker.fire(options);
+        } catch (error) {
+            if (!this.fallback) {
+                throw new HttpClientError(
+                    `Error on ${options.method} ${options.origin}${options.path}`,
+                    {
+                        code: error.code,
+                        cause: error,
+                        options,
+                    },
+                );
+            }
+        }
     }
 
     /**
@@ -129,5 +142,18 @@ export default class HttpClient {
         if (!this.#agent.destroyed && !this.#agent.closed) {
             await this.#agent.close();
         }
+    }
+}
+
+/**
+ * Error class for the client
+ */
+export class HttpClientError extends Error {
+    constructor(message, { code, cause, options }) {
+        super(message);
+        this.name = 'HttpClientError';
+        this.code = code;
+        this.cause = cause;
+        this.options = options;
     }
 }

--- a/package.json
+++ b/package.json
@@ -43,11 +43,12 @@
     "@podium/semantic-release-config": "2.0.0",
     "@podium/typescript-config": "1.0.0",
     "@types/node": "20.16.10",
+    "@types/opossum": "8.1.8",
     "concurrently": "9.0.1",
     "cronometro": "4.0.0",
     "eslint": "9.11.1",
-    "prettier": "3.3.3",
     "npm-run-all2": "6.2.6",
+    "prettier": "3.3.3",
     "table": "6.8.2",
     "typescript": "5.6.3",
     "wait-on": "8.0.1"

--- a/tests/http-client.test.js
+++ b/tests/http-client.test.js
@@ -3,91 +3,120 @@ import assert from 'node:assert/strict';
 import http from 'node:http';
 
 import HttpClient from '../lib/http-client.js';
+import { wait } from './utilities.js';
 
 let httpServer,
     host = 'localhost',
     port = 3003;
 
-async function beforeEach() {
+const url = `http://${host}:${port}`;
+
+function beforeEach() {
     httpServer = http.createServer(async (request, response) => {
         response.writeHead(200);
         response.end();
     });
-    httpServer.listen(port, host, () => Promise.resolve());
+    httpServer.listen(port, host);
 }
 
+function closeServer() {
+    return new Promise((resolve) => {
+        httpServer.close(resolve);
+        console.log('Closed');
+    });
+}
 async function afterEach(client) {
     await client.close();
-    await httpServer.close();
+    await closeServer();
 }
 
-test('http-client - basics', async (t) => {
-    await t.test(
-        'http-client: returns 200 response when given valid input',
-        async () => {
-            await beforeEach();
-            const url = `http://${host}:${port}`;
-            const client = new HttpClient();
-            const response = await client.request({
-                path: '/',
-                origin: url,
-                method: 'GET',
-            });
-            assert.strictEqual(response.statusCode, 200);
-            await afterEach(client);
-        },
-    );
-
-    await t.test('does not cause havoc with built in fetch', async () => {
-        await beforeEach();
-        const url = `http://${host}:${port}`;
+async function queryUrl({
+    client,
+    path = '/',
+    url = `http://${host}:${port}`,
+    loop = 2,
+    supresErrors = true,
+}) {
+    for (let i = 0; i < loop; i++) {
+        try {
+            await client.request({ path, origin: url, method: 'GET' });
+        } catch (err) {
+            if (!supresErrors) throw err;
+        }
+    }
+}
+await test('http-client - basics', async (t) => {
+    await t.test('returns 200 response when given valid input', async () => {
+        beforeEach();
         const client = new HttpClient();
-        await fetch(url);
         const response = await client.request({
             path: '/',
             origin: url,
             method: 'GET',
         });
         assert.strictEqual(response.statusCode, 200);
-        await client.close();
-        await fetch(url);
         await afterEach(client);
     });
 
-    await test.skip('http-client: should not invalid port input', async () => {
-        await beforeEach();
-        const url = `http://${host}:3013`;
+    // await t.test('does not cause havoc with built in fetch', async () => {
+    //     beforeEach();
+    //     const client = new HttpClient();
+    //     await fetch(url);
+    //     const response = await client.request({
+    //         path: '/',
+    //         origin: url,
+    //         method: 'GET',
+    //     });
+    //     assert.strictEqual(response.statusCode, 200);
+    //     await client.close();
+    //     await fetch(url);
+    //     await afterEach(client);
+    // });
+    await t.test('can pass in an abort controller', async () => {
+        beforeEach();
+        const abortController = new AbortController();
+
         const client = new HttpClient();
-        await client.request({
-            path: '/',
-            origin: url,
-            method: 'GET',
-        });
         const response = await client.request({
             path: '/',
             origin: url,
             method: 'GET',
         });
-        assert.strictEqual(response.statusCode, 200);
         await afterEach(client);
     });
 });
 
-test.skip('http-client circuit breaker behaviour', async (t) => {
-    await t.test('closes on failure threshold', async () => {
-        await beforeEach();
-        const url = `http://${host}:3014`;
-        const client = new HttpClient({ threshold: 2 });
-        await client.request({
-            path: '/',
-            origin: url,
-            method: 'GET',
+await test('http-client - circuit breaker behaviour', async (t) => {
+    await t.test('opens on failure threshold', async () => {
+        beforeEach();
+        const invalidUrl = `http://${host}:3013`;
+        const client = new HttpClient({ threshold: 50 });
+        let hasOpened = false;
+        client.on('open', () => {
+            hasOpened = true;
         });
+        await queryUrl({ client, url: invalidUrl });
+
+        assert.strictEqual(hasOpened, true);
+        await afterEach(client);
+    });
+    await t.test('can reset breaker', async () => {
+        beforeEach();
+        const invalidUrl = `http://${host}:3013`;
+        const client = new HttpClient({ threshold: 50, reset: 1 });
+        await queryUrl({ client, url: invalidUrl });
+
+        let hasClosed = false;
+        client.on('close', () => {
+            hasClosed = true;
+        });
+        await wait();
         const response = await client.request({
             path: '/',
             origin: url,
             method: 'GET',
         });
+        assert.strictEqual(hasClosed, true);
         assert.strictEqual(response.statusCode, 200);
         await afterEach(client);
     });

--- a/tests/utilities.js
+++ b/tests/utilities.js
@@ -1,0 +1,12 @@
+/**
+ * Wait a little bit, promise based.
+ * @property {Number} [waitTime=1000]
+ * @returns {Promise<void>}
+ */
+export async function wait(waitTime = 1000) {
+    return new Promise((resolve) => {
+        setTimeout(async () => {
+            resolve();
+        }, waitTime);
+    });
+}

--- a/tests/utilities.js
+++ b/tests/utilities.js
@@ -10,3 +10,11 @@ export async function wait(waitTime = 1000) {
         }, waitTime);
     });
 }
+export async function slowResponder(func, timeout = 1000) {
+    return new Promise((resolve) => {
+        setTimeout(async () => {
+            await func();
+            resolve();
+        }, timeout);
+    });
+}


### PR DESCRIPTION
WIP - Creating an improved HTTP client which has a circuit breaker.

Note, these are just notes 😄 
## Todos

- [ ] identify the metrics on `client` which we need to continue having
- [ ] add metrics support
- [ ] add prometheus hook into opossum
- [ ] close the gap on features in client and this one.... not sure what those are yet.

## Open questions ❓

- ~`request` which we are using here is _single origin_, which means that a request to `https://google.com` returning a `location` header with `https://www.google.com` will _not_ redirect as it's a different host. the [client](https://github.com/podium-lib/client/) implementation supports `redirectable` and it's [used in the resolvers](https://github.com/podium-lib/client/blob/f5ed0d5aa2b5ff58feb6b27a68c7383ea449d6a3/lib/resolver.content.js#L145)~
- decide on default redirect behaviour
- decide on options surface, how much control should there be?
- should we rename this branch to `alpha` to create a release?
- do we add retries to the client?

## Errors

If `options.fallback` is not set, we wrap errors in a `HttpClientError` class.

```js
const client = new HttpClient();
try {
  await client.request(...)
} catch (err) {
 if (err instance of HttpClientError) {
  // do stuff
 }
}
```
## Constructor options
### abortController

we need to be able to [cancel requests in opossum](https://github.com/nodeshift/opossum?tab=readme-ov-file#abortcontroller-support)

### followRedirects
if we should follow redirects or not, default behaviour is to not follow (???)

### fallback

```js
const client = new HttpClient({ fallback: function () { return 'We are down.' } });
// can also be set like this

client.fallback(function () { 'We are down'; });
```

Closes #11 